### PR TITLE
Cleanup

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -5,9 +5,20 @@
  */
 
 return array(
+    'service_manager' => array(
+        'factories' => array(
+            'ZF\ContentNegotiation\AcceptListener'            => 'ZF\ContentNegotiation\Factory\AcceptListenerFactory',
+            'ZF\ContentNegotiation\AcceptFilterListener'      => 'ZF\ContentNegotiation\Factory\AcceptFilterListenerFactory',
+            'ZF\ContentNegotiation\ContentTypeFilterListener' => 'ZF\ContentNegotiation\Factory\ContentTypeFilterListenerFactory',
+        )
+    ),
+
     'zf-content-negotiation' => array(
+        // ???? Comment about it ?
         'controllers' => array(),
-        'selectors' => array(
+
+        // ???? Comment about it ?
+        'selectors'   => array(
             'Json' => array(
                 'ZF\ContentNegotiation\JsonModel' => array(
                     'application/json',
@@ -15,23 +26,24 @@ return array(
                 ),
             ),
         ),
-        'accept-whitelist' => array(
-            // Array of controller service name => allowed accept header pairs.
-            // The allowed content type may be a string, or an array of strings.
-        ),
-        'content-type-whitelist' => array(
-            // Array of controller service name => allowed content type pairs.
-            // The allowed content type may be a string, or an array of strings.
-        ),
+
+        // Array of controller service name => allowed accept header pairs.
+        // The allowed content type may be a string, or an array of strings.
+        'accept_whitelist' => array(),
+
+        // Array of controller service name => allowed content type pairs.
+        // The allowed content type may be a string, or an array of strings.
+        'content_type_whitelist' => array(),
     ),
+
     'controller_plugins' => array(
         'invokables' => array(
-            'routeParam'                 => 'ZF\ContentNegotiation\ControllerPlugin\RouteParam',
-            'queryParam'                 => 'ZF\ContentNegotiation\ControllerPlugin\QueryParam',
-            'bodyParam'                  => 'ZF\ContentNegotiation\ControllerPlugin\BodyParam',
-            'routeParams'                => 'ZF\ContentNegotiation\ControllerPlugin\RouteParams',
-            'queryParams'                => 'ZF\ContentNegotiation\ControllerPlugin\QueryParams',
-            'bodyParams'                 => 'ZF\ContentNegotiation\ControllerPlugin\BodyParams',
+            'routeParam'  => 'ZF\ContentNegotiation\ControllerPlugin\RouteParam',
+            'queryParam'  => 'ZF\ContentNegotiation\ControllerPlugin\QueryParam',
+            'bodyParam'   => 'ZF\ContentNegotiation\ControllerPlugin\BodyParam',
+            'routeParams' => 'ZF\ContentNegotiation\ControllerPlugin\RouteParams',
+            'queryParams' => 'ZF\ContentNegotiation\ControllerPlugin\QueryParams',
+            'bodyParams'  => 'ZF\ContentNegotiation\ControllerPlugin\BodyParams',
         )
     )
 );

--- a/src/ZF/ContentNegotiation/Factory/AcceptFilterListenerFactory.php
+++ b/src/ZF/ContentNegotiation/Factory/AcceptFilterListenerFactory.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2013 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\ContentNegotiation\Factory;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZF\ContentNegotiation\AcceptFilterListener;
+
+class AcceptFilterListenerFactory implements FactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $listener = new AcceptFilterListener();
+        $config   = array();
+
+        if ($serviceLocator->has('Config')) {
+            $moduleConfig = false;
+            $appConfig    = $serviceLocator->get('Config');
+            if (isset($appConfig['zf-content-negotiation'])
+                && is_array($appConfig['zf-content-negotiation'])
+            ) {
+                $moduleConfig = $appConfig['zf-content-negotiation'];
+            }
+
+            if ($moduleConfig
+                && isset($moduleConfig['accept_whitelist'])
+                && is_array($moduleConfig['accept_whitelist'])
+            ) {
+                $config = $moduleConfig['accept_whitelist'];
+            }
+        }
+
+        if (!empty($config)) {
+            $listener->setConfig($config);
+        }
+
+        return $listener;
+    }
+}

--- a/src/ZF/ContentNegotiation/Factory/AcceptListenerFactory.php
+++ b/src/ZF/ContentNegotiation/Factory/AcceptListenerFactory.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2013 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\ContentNegotiation\Factory;
+
+use Zend\Mvc\Controller\Plugin\AcceptableViewModelSelector;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZF\ContentNegotiation\AcceptListener;
+
+class AcceptListenerFactory implements FactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $config = array();
+
+        if ($serviceLocator->has('Config')) {
+            $appConfig = $serviceLocator->get('Config');
+            if (isset($appConfig['zf-content-negotiation'])
+                && is_array($appConfig['zf-content-negotiation'])
+            ) {
+                $config = $appConfig['zf-content-negotiation'];
+            }
+        }
+
+        $selector = null;
+        if ($serviceLocator->has('ControllerPluginManager')) {
+            $plugins = $serviceLocator->get('ControllerPluginManager');
+            if ($plugins->has('AcceptableViewModelSelector')) {
+                $selector = $plugins->get('AcceptableViewModelSelector');
+            }
+        }
+
+        if (null === $selector) {
+            $selector = new AcceptableViewModelSelector();
+        }
+
+        return new AcceptListener($selector, $config);
+    }
+}

--- a/src/ZF/ContentNegotiation/Factory/ContentTypeFilterListenerFactory.php
+++ b/src/ZF/ContentNegotiation/Factory/ContentTypeFilterListenerFactory.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2013 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\ContentNegotiation\Factory;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZF\ContentNegotiation\ContentTypeFilterListener;
+
+class ContentTypeFilterListenerFactory implements FactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $listener = new ContentTypeFilterListener();
+        $config   = array();
+
+        if ($serviceLocator->has('Config')) {
+            $moduleConfig = false;
+            $appConfig    = $serviceLocator->get('Config');
+            if (isset($appConfig['zf-content-negotiation'])
+                && is_array($appConfig['zf-content-negotiation'])
+            ) {
+                $moduleConfig = $appConfig['zf-content-negotiation'];
+            }
+
+            if ($moduleConfig
+                && isset($moduleConfig['content_type_whitelist'])
+                && is_array($moduleConfig['content_type_whitelist'])
+            ) {
+                $config = $moduleConfig['content_type_whitelist'];
+            }
+        }
+
+        if (!empty($config)) {
+            $listener->setConfig($config);
+        }
+
+        return $listener;
+    }
+}

--- a/src/ZF/ContentNegotiation/Module.php
+++ b/src/ZF/ContentNegotiation/Module.php
@@ -11,6 +11,9 @@ use Zend\Mvc\MvcEvent;
 
 class Module
 {
+    /**
+     * {@inheritDoc}
+     */
     public function getAutoloaderConfig()
     {
         return array(
@@ -22,94 +25,17 @@ class Module
         );
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getConfig()
     {
         return include __DIR__ . '/../../../config/module.config.php';
     }
 
-    public function getServiceConfig()
-    {
-        return array('factories' => array(
-            'ZF\ContentNegotiation\AcceptListener' => function ($services) {
-                $config = array();
-                if ($services->has('Config')) {
-                    $appConfig = $services->get('Config');
-                    if (isset($appConfig['zf-content-negotiation'])
-                        && is_array($appConfig['zf-content-negotiation'])
-                    ) {
-                        $config = $appConfig['zf-content-negotiation'];
-                    }
-                }
-
-                $selector = null;
-                if ($services->has('ControllerPluginManager')) {
-                    $plugins = $services->get('ControllerPluginManager');
-                    if ($plugins->has('AcceptableViewModelSelector')) {
-                        $selector = $plugins->get('AcceptableViewModelSelector');
-                    }
-                }
-                if (null === $selector) {
-                    $selector = new AcceptableViewModelSelector();
-                }
-                return new AcceptListener($selector, $config);
-            },
-            'ZF\ContentNegotiation\AcceptFilterListener' => function ($services) {
-                $listener = new AcceptFilterListener();
-
-                $config   = array();
-                if ($services->has('Config')) {
-                    $moduleConfig = false;
-                    $appConfig    = $services->get('Config');
-                    if (isset($appConfig['zf-content-negotiation'])
-                        && is_array($appConfig['zf-content-negotiation'])
-                    ) {
-                        $moduleConfig = $appConfig['zf-content-negotiation'];
-                    }
-
-                    if ($moduleConfig
-                        && isset($moduleConfig['accept-whitelist'])
-                        && is_array($moduleConfig['accept-whitelist'])
-                    ) {
-                        $config = $moduleConfig['accept-whitelist'];
-                    }
-                }
-
-                if (!empty($config)) {
-                    $listener->setConfig($config);
-                }
-
-                return $listener;
-            },
-            'ZF\ContentNegotiation\ContentTypeFilterListener' => function ($services) {
-                $listener = new ContentTypeFilterListener();
-
-                $config   = array();
-                if ($services->has('Config')) {
-                    $moduleConfig = false;
-                    $appConfig    = $services->get('Config');
-                    if (isset($appConfig['zf-content-negotiation'])
-                        && is_array($appConfig['zf-content-negotiation'])
-                    ) {
-                        $moduleConfig = $appConfig['zf-content-negotiation'];
-                    }
-
-                    if ($moduleConfig
-                        && isset($moduleConfig['content-type-whitelist'])
-                        && is_array($moduleConfig['content-type-whitelist'])
-                    ) {
-                        $config = $moduleConfig['content-type-whitelist'];
-                    }
-                }
-
-                if (!empty($config)) {
-                    $listener->setConfig($config);
-                }
-
-                return $listener;
-            },
-        ));
-    }
-
+    /**
+     * {@inheritDoc}
+     */
     public function onBootstrap($e)
     {
         $app      = $e->getApplication();


### PR DESCRIPTION
As stated on API problem, create factories and rename the options to use underscore_separated convention.

When you merge, can you add a few comments about the two keys of the config? I'm not sure about what they are doing (and the format to 'selectors' key seems a bit hard without any doc :o).

In the factories, I'm not sure it's that useful to test for "has" for the Config key. I think we can remove that no?
