### PR TITLE
Added ability for JsonModel to accept variables via \JsonSerializable

### DIFF
--- a/src/ZF/ContentNegotiation/JsonModel.php
+++ b/src/ZF/ContentNegotiation/JsonModel.php
@@ -16,4 +16,12 @@ class JsonModel extends BaseJsonModel
      * @var bool
      */
     protected $terminate = true;
+
+    public function setVariables($variables, $overwrite = false)
+    {
+        if ($variables instanceof \JsonSerializable) {
+            $variables = $variables->jsonSerialize();
+        }
+        return parent::setVariables($variables, $overwrite);
+    }
 }

--- a/test/ZFTest/ContentNegotiation/JsonModelTest.php
+++ b/test/ZFTest/ContentNegotiation/JsonModelTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ZFTest\ContentNegotiation;
+
+use ZF\ContentNegotiation\JsonModel;
+
+class JsonModelTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSetVariables()
+    {
+        $jsonModel = new JsonModel(new TestAsset\ModelWithJson());
+        $this->assertEquals('bar', $jsonModel->getVariable('foo'));
+    }
+}
+ 

--- a/test/ZFTest/ContentNegotiation/TestAsset/ModelWithJson.php
+++ b/test/ZFTest/ContentNegotiation/TestAsset/ModelWithJson.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace ZFTest\ContentNegotiation\TestAsset;
+
+class ModelWithJson implements \JsonSerializable
+{
+    public function jsonSerialize()
+    {
+        return array('foo' => 'bar');
+    }
+}


### PR DESCRIPTION
This will allow JsonModel to accept via setVariables() an array delivered though jsonSerialize() 
