### PR TITLE
ContentNegotiation JsonModel should always be terminal

### DIFF
--- a/src/ZF/ContentNegotiation/JsonModel.php
+++ b/src/ZF/ContentNegotiation/JsonModel.php
@@ -23,9 +23,9 @@ class JsonModel extends BaseJsonModel
      * Set variables
      *
      * Overrides parent to extract variables from JsonSerializable objects.
-     * 
-     * @param  array|Traversable|JsonSerializable|StdlibJsonSerializable $variables 
-     * @param  bool $overwrite 
+     *
+     * @param  array|Traversable|JsonSerializable|StdlibJsonSerializable $variables
+     * @param  bool $overwrite
      * @return self
      */
     public function setVariables($variables, $overwrite = false)
@@ -36,5 +36,19 @@ class JsonModel extends BaseJsonModel
             $variables = $variables->jsonSerialize();
         }
         return parent::setVariables($variables, $overwrite);
+    }
+
+    /**
+     * Override setTerminal()
+     *
+     * Becomes a no-op; this model should always be terminal.
+     *
+     * @param  bool $flag
+     * @return self
+     */
+    public function setTerminal($flag)
+    {
+        // Do nothing; should always terminate
+        return $this;
     }
 }

--- a/test/ZFTest/ContentNegotiation/JsonModelTest.php
+++ b/test/ZFTest/ContentNegotiation/JsonModelTest.php
@@ -16,4 +16,11 @@ class JsonModelTest extends TestCase
         $jsonModel = new JsonModel(new TestAsset\ModelWithJson());
         $this->assertEquals('bar', $jsonModel->getVariable('foo'));
     }
+
+    public function testJsonModelIsAlwaysTerminal()
+    {
+        $jsonModel = new JsonModel(array());
+        $jsonModel->setTerminal(false);
+        $this->assertTrue($jsonModel->terminate());
+    }
 }


### PR DESCRIPTION
- In APIs, you rarely if ever want to nest, so the top-level result should be
  marked terminal.
