### PR TITLE
Implement file uploads for PATCH and PUT requests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,8 @@
         "php": ">=5.3.23",
         "zendframework/zend-eventmanager": "~2.3",
         "zendframework/zend-json": "~2.3",
+        "zendframework/zend-mail": "~2.3",
+        "zendframework/zend-mime": "~2.3",
         "zendframework/zend-mvc": "~2.3",
         "zendframework/zend-servicemanager": "~2.3",
         "zendframework/zend-stdlib": "~2.3",

--- a/src/ContentTypeListener.php
+++ b/src/ContentTypeListener.php
@@ -6,7 +6,9 @@
 
 namespace ZF\ContentNegotiation;
 
+use Zend\Mime\Decode;
 use Zend\Mvc\MvcEvent;
+use Zend\Stdlib\Parameters;
 use ZF\ApiProblem\ApiProblem;
 use ZF\ApiProblem\ApiProblemResponse;
 
@@ -66,6 +68,12 @@ class ContentTypeListener
             case $request::METHOD_PATCH:
             case $request::METHOD_PUT:
                 $content = $request->getContent();
+
+                if ($contentType && $contentType->match('multipart/form-data')) {
+                    $bodyParams = $this->parseMultipartContent($content, $contentType, $request, $e);
+                    break;
+                }
+
                 if ($contentType && $contentType->match('application/json')) {
                     $bodyParams = $this->decodeJson($content);
                     break;
@@ -92,6 +100,36 @@ class ContentTypeListener
     }
 
     /**
+     * Remove upload files if still present in filesystem
+     *
+     * @param MvcEvent $e
+     */
+    public function onFinish(MvcEvent $e)
+    {
+        $request      = $e->getRequest();
+        $uploadTmpDir = $this->getUploadTempDir();
+
+        foreach ($request->getFiles() as $name => $fileInfo) {
+            $tmpDir  = dirname($fileInfo['tmp_name']);
+            if (dirname($fileInfo['tmp_name']) !== $uploadTmpDir) {
+                // File was moved
+                continue;
+            }
+
+            if (! preg_match('/^zfc/', basename($fileInfo['tmp_name']))) {
+                // File was moved
+                continue;
+            }
+
+            if (! file_exists($fileInfo['tmp_name'])) {
+                continue;
+            }
+
+            unlink($fileInfo['tmp_name']);
+        }
+    }
+
+    /**
      * Attempt to decode a JSON string
      *
      * Decodes a JSON string and returns it; if invalid, returns
@@ -115,5 +153,162 @@ class ContentTypeListener
         return new ApiProblemResponse(
             new ApiProblem(400, sprintf('JSON decoding error: %s', $message))
         );
+    }
+
+    /**
+     * Retrieve the upload temporary directory
+     *
+     * Queries for the INI upload_tmp_dir setting first, and returns that
+     * value if set and a valid directory; otherwise, returns the
+     * system_temp_dir().
+     *
+     * @return string
+     */
+    public function getUploadTempDir()
+    {
+        $tmpDir = ini_get('upload_tmp_dir');
+        if (! empty($tmpDir) && is_dir($tmpDir)) {
+            return $tmpDir;
+        }
+
+        return sys_get_temp_dir();
+    }
+
+    /**
+     * Parse multipart/form-data content
+     *
+     * Splits parts into MIME parts, and iterates over each.
+     *
+     * If the part represents a variable (no "filename" indicated in the
+     * Content-Disposition), then the value is added to the set of body
+     * parameters.
+     *
+     * If a part represents a file, we pass it to uploadFile() and add the
+     * entry to a parameter container of files; if any files were present at
+     * all, the files parameter container is injected into the request.
+     *
+     * If no boundary is present in the request's Content-Type header, then the
+     * method raises an exception.
+     *
+     * @param string $content
+     * @param \Zend\Http\Header\HeaderInterface $contentType
+     * @param \Zend\Http\Request $request
+     * @param MvcEvent $event
+     * @return array
+     * @throws Exception\InvalidMultipartContentException
+     */
+    protected function parseMultipartContent($content, $contentType, $request, MvcEvent $event)
+    {
+        if (! preg_match('/boundary=(?P<boundary>[^\s]+)/', $contentType->getFieldValue(), $matches)) {
+            throw new Exception\InvalidMultipartContentException();
+        }
+
+        $boundary = $matches['boundary'];
+        $data     = new Parameters();
+        $files    = new Parameters();
+        foreach (Decode::splitMessageStruct($content, $boundary) as $part) {
+            $this->parseMimePart($part, $data, $files);
+        }
+
+        if ($files->count()) {
+            $request->setFiles($files);
+            $this->attachFileCleanupListener($event);
+        }
+
+        return $data->toArray();
+    }
+
+    /**
+     * Parse a single MIME part
+     *
+     * Extracts either form data or files, depending on the Content-Disposition
+     * of the MIME part, injecting the appropriate container ($data or $files).
+     *
+     * @param array $part
+     * @param Parameters $data
+     * @param Parameters $files
+     */
+    protected function parseMimePart(array $part, Parameters $data, Parameters $files)
+    {
+        $headers = $part['header'];
+        if (! $headers->has('Content-Disposition')) {
+            return;
+        }
+
+        $disposition = $headers->get('Content-Disposition')->getFieldValue();
+        if (! preg_match('/(?:;|\s)name="(?P<name>[^"]+)"/', $disposition, $matches)) {
+            // unnamed parameter; move along...
+            return;
+        }
+        $name = $matches['name'];
+
+        if (preg_match('/filename="(?P<filename>[^"]*)"/', $disposition, $matches)) {
+            $files->set($name, $this->uploadFile(
+                $matches['filename'],
+                $headers->has('Content-Type') ? $headers->get('Content-Type')->getFieldValue() : 'application/octet-stream',
+                $part['body']));
+            return;
+        }
+
+        $data->set($name, rtrim($part['body'], "\r\n"));
+    }
+
+    /**
+     * Mimic PHP's file upload functionality
+     *
+     * This mimics PHP's file upload functionality by taking the provided
+     * content and attempting to write it to a temporary file in either
+     * the upload_tmp_dir or * system tmp directory.
+     *
+     * Returns a struct in the same format as used for elements of the
+     * $_FILES array.
+     *
+     * @todo At some point, we likely need to support using a stream for file
+     *       uploads in order to prevent memory issues.
+     * @param string $filename
+     * @param string $contentType
+     * @param string $content
+     * @return array
+     */
+    protected function uploadFile($filename, $contentType, $content)
+    {
+        $tmpDir = $this->getUploadTempDir();
+        $file   = array(
+            'name' => $filename,
+            'type' => $contentType,
+        );
+
+        if (empty($tmpDir)) {
+            $file['error'] = UPLOAD_ERR_NO_TMP_DIR;
+            return $file;
+        }
+
+        $tmpFile = tempnam($tmpDir, 'zfc');
+        $file['tmp_name'] = $tmpFile;
+
+        if (false === file_put_contents($tmpFile, rtrim($content, "\r\n"))) {
+            $file['error'] = UPLOAD_ERR_CANT_WRITE;
+            return $file;
+        }
+
+        $file['error'] = UPLOAD_ERR_OK;
+        $file['size']  = filesize($tmpFile);
+        return $file;
+    }
+
+    /**
+     * Attach the file cleanup listener
+     *
+     * @param MvcEvent $event
+     */
+    protected function attachFileCleanupListener(MvcEvent $event)
+    {
+        $target = $event->getTarget();
+        if (! $target || ! is_object($target) || ! method_exists($target, 'getEventManager')) {
+            return;
+        }
+
+        $events = $target->getEventManager();
+        $events->attach('finish', array($this, 'onFinish'), 1000);
     }
 }

--- a/src/Exception/InvalidMultipartContentException.php
+++ b/src/Exception/InvalidMultipartContentException.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\ContentNegotiation\Exception;
+
+use DomainException;
+
+class InvalidMultipartContentException extends DomainException implements ExceptionInterface
+{
+}

--- a/test/ContentTypeListenerTest.php
+++ b/test/ContentTypeListenerTest.php
@@ -10,6 +10,7 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Http\Request;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\Router\RouteMatch;
+use Zend\Stdlib\Parameters;
 use ZF\ContentNegotiation\ContentTypeListener;
 
 class ContentTypeListenerTest extends TestCase
@@ -50,5 +51,154 @@ class ContentTypeListenerTest extends TestCase
         $problem = $result->getApiProblem();
         $this->assertEquals(400, $problem->status);
         $this->assertContains('JSON decoding', $problem->detail);
+    }
+
+    public function multipartFormDataMethods()
+    {
+        return array(
+            'patch' => array('patch'),
+            'put'   => array('put'),
+        );
+    }
+
+    /**
+     * @dataProvider multipartFormDataMethods
+     */
+    public function testCanDecodeMultipartFormDataRequestsForPutAndPatchOperations($method)
+    {
+        $request = new Request();
+        $request->setMethod($method);
+        $request->getHeaders()->addHeaderLine('Content-Type', 'multipart/form-data; boundary=6603ddd555b044dc9a022f3ad9281c20');
+        $request->setContent(file_get_contents( __DIR__ . '/TestAsset/multipart-form-data.txt'));
+
+        $event = new MvcEvent();
+        $event->setRequest($request);
+        $event->setRouteMatch(new RouteMatch(array()));
+
+        $listener = $this->listener;
+        $result = $listener($event);
+
+        $parameterData = $event->getParam('ZFContentNegotiationParameterData');
+        $params = $parameterData->getBodyParams();
+        $this->assertEquals(array(
+            'mime_type' => 'md',
+        ), $params);
+
+        $files = $request->getFiles();
+        $this->assertEquals(1, $files->count());
+        $file = $files->get('text');
+        $this->assertInternalType('array', $file);
+        $this->assertArrayHasKey('error', $file);
+        $this->assertArrayHasKey('name', $file);
+        $this->assertArrayHasKey('tmp_name', $file);
+        $this->assertArrayHasKey('size', $file);
+        $this->assertArrayHasKey('type', $file);
+        $this->assertEquals('README.md', $file['name']);
+        $this->assertRegexp('/^zfc/', basename($file['tmp_name']));
+        $this->assertTrue(file_exists($file['tmp_name']));
+    }
+
+    public function testDecodingMultipartFormDataWithFileRegistersFileCleanupEventListener()
+    {
+        $request = new Request();
+        $request->setMethod('PATCH');
+        $request->getHeaders()->addHeaderLine('Content-Type', 'multipart/form-data; boundary=6603ddd555b044dc9a022f3ad9281c20');
+        $request->setContent(file_get_contents( __DIR__ . '/TestAsset/multipart-form-data.txt'));
+
+        $target = new TestAsset\EventTarget();
+        $events = $this->getMock('Zend\EventManager\EventManagerInterface');
+        $events->expects($this->once())
+            ->method('attach')
+            ->with(
+                $this->equalTo('finish'),
+                $this->equalTo(array($this->listener, 'onFinish')),
+                $this->equalTo(1000)
+            );
+        $target->events = $events;
+
+        $event = new MvcEvent();
+        $event->setTarget($target);
+        $event->setRequest($request);
+        $event->setRouteMatch(new RouteMatch(array()));
+
+        $listener = $this->listener;
+        $result = $listener($event);
+    }
+
+    public function testOnFinishWillRemoveAnyUploadFilesUploadedByTheListener()
+    {
+        $tmpDir  = $this->listener->getUploadTempDir();
+        $tmpFile = tempnam($tmpDir, 'zfc');
+        file_put_contents($tmpFile, 'File created by ' . __CLASS__);
+
+        $files = new Parameters(array(
+            'test' => array(
+                'error'    => UPLOAD_ERR_OK,
+                'name'     => 'test.txt',
+                'type'     => 'text/plain',
+                'tmp_name' => $tmpFile,
+                'size'     => filesize($tmpFile),
+            ),
+        ));
+        $request = new Request();
+        $request->setFiles($files);
+
+        $event = new MvcEvent();
+        $event->setRequest($request);
+
+        $this->listener->onFinish($event);
+        $this->assertFalse(file_exists($tmpFile));
+    }
+
+    public function testOnFinishDoesNotRemoveUploadFilesTheListenerDidNotCreate()
+    {
+        $tmpDir  = $this->listener->getUploadTempDir();
+        $tmpFile = tempnam($tmpDir, 'php');
+        file_put_contents($tmpFile, 'File created by ' . __CLASS__);
+
+        $files = new Parameters(array(
+            'test' => array(
+                'error'    => UPLOAD_ERR_OK,
+                'name'     => 'test.txt',
+                'type'     => 'text/plain',
+                'tmp_name' => $tmpFile,
+                'size'     => filesize($tmpFile),
+            ),
+        ));
+        $request = new Request();
+        $request->setFiles($files);
+
+        $event = new MvcEvent();
+        $event->setRequest($request);
+
+        $this->listener->onFinish($event);
+        $this->assertTrue(file_exists($tmpFile));
+        unlink($tmpFile);
+    }
+
+    public function testOnFinishDoesNotRemoveUploadFilesThatHaveBeenMoved()
+    {
+        $tmpDir  = sys_get_temp_dir() . '/' . str_replace('\\', '_', __CLASS__);
+        mkdir($tmpDir);
+        $tmpFile = tempnam($tmpDir, 'zfc');
+
+        $files = new Parameters(array(
+            'test' => array(
+                'error'    => UPLOAD_ERR_OK,
+                'name'     => 'test.txt',
+                'type'     => 'text/plain',
+                'tmp_name' => $tmpFile,
+            ),
+        ));
+        $request = new Request();
+        $request->setFiles($files);
+
+        $event = new MvcEvent();
+        $event->setRequest($request);
+
+        $this->listener->onFinish($event);
+        $this->assertTrue(file_exists($tmpFile));
+        unlink($tmpFile);
+        rmdir($tmpDir);
     }
 }

--- a/test/TestAsset/EventTarget.php
+++ b/test/TestAsset/EventTarget.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\ContentNegotiation\TestAsset;
+
+class EventTarget
+{
+    public $events;
+
+    public function getEventManager()
+    {
+        return $this->events;
+    }
+}

--- a/test/TestAsset/multipart-form-data.txt
+++ b/test/TestAsset/multipart-form-data.txt
@@ -1,0 +1,15 @@
+--6603ddd555b044dc9a022f3ad9281c20
+Content-Disposition: form-data; name="mime_type"
+Content-Type: text/plain
+
+md
+--6603ddd555b044dc9a022f3ad9281c20
+Content-Disposition: form-data; name="text"; filename="README.md"
+Content-Type: application/octet-stream
+
+ZF Content Negotiation
+======================
+
+[![Build Status](https://travis-ci.org/zfcampus/zf-api-problem.png)](https://travis-ci.org/zfcampus/zf-api-problem)
+
+--6603ddd555b044dc9a022f3ad9281c20--


### PR DESCRIPTION
`multipart/form-data` is natively supported via POST by PHP. However, PATCH
and PUT are not; you need to parse the request body and separate the parts
into:
- form data
- file uploads

Additionally, for each file upload, you need to mimic how PHP uploads files,
and create a `$_FILES` compatible array.

This patch does the following:
- Adds support for parsing `multipart/form-data` request bodies, via
  `Zend\Mime`.
- Injects any discovered form data parameters into the
  `ParameterDataContainer`,
  making them available later via the `bodyParam*()` plugins.
- Performs file uploads on any discovered files. This involves creating a
  temporary file in either the `upload_tmp_dir` or system temporary directory
  (depending on current configuration). Files are created using the prefix
  `zfc`
  to make them identifiable later. A `$_FILES`-compatible entry is created for
  each upload, and injected into the response's files container.
- If any file uploads were discovered, it registers a listener on the "finish"
  event to remove any files still remaining. The assumption is that you will
  move or rename any upload files.
