### PR TITLE
Rolling back ContentTypeListener deleteList changes.

### DIFF
--- a/src/ContentTypeListener.php
+++ b/src/ContentTypeListener.php
@@ -75,7 +75,6 @@ class ContentTypeListener
                 break;
             case $request::METHOD_PATCH:
             case $request::METHOD_PUT:
-            case $request::METHOD_DELETE:
                 $content = $request->getContent();
 
                 if ($contentType && $contentType->match('multipart/form-data')) {

--- a/test/ContentTypeListenerTest.php
+++ b/test/ContentTypeListenerTest.php
@@ -29,7 +29,6 @@ class ContentTypeListenerTest extends TestCase
             'post' => array('POST'),
             'patch' => array('PATCH'),
             'put' => array('PUT'),
-            'delete' => array('DELETE'),
         );
     }
 
@@ -62,14 +61,13 @@ class ContentTypeListenerTest extends TestCase
         return array(
             'patch'  => array('patch'),
             'put'    => array('put'),
-            'delete' => array('delete'),
         );
     }
 
     /**
      * @dataProvider multipartFormDataMethods
      */
-    public function testCanDecodeMultipartFormDataRequestsForPutPatchAndDeleteOperations($method)
+    public function testCanDecodeMultipartFormDataRequestsForPutAndPatchOperations($method)
     {
         $request = new Request();
         $request->setMethod($method);


### PR DESCRIPTION
Taking out the case for METHOD_DELETE since the $request->getContent() is always returning an empty body when using deleteList().