### PR TITLE
Changed registering of `ContentTypeListener`

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -41,7 +41,7 @@ class Module
         $services = $app->getServiceManager();
         $em       = $app->getEventManager();
 
-        $em->attach(MvcEvent::EVENT_ROUTE, new ContentTypeListener(), -625);
+        $em->attach(MvcEvent::EVENT_ROUTE, $services->get('ZF\ContentNegotiation\ContentTypeListener'), -625);
         $em->attachAggregate($services->get('ZF\ContentNegotiation\AcceptFilterListener'));
         $em->attachAggregate($services->get('ZF\ContentNegotiation\ContentTypeFilterListener'));
 

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -24,6 +24,9 @@ return array(
     ),
 
     'service_manager' => array(
+        'invokables' => array(
+            'ZF\ContentNegotiation\ContentTypeListener' => 'ZF\ContentNegotiation\ContentTypeListener'
+        ),
         'factories' => array(
             'Request'                                         => 'ZF\ContentNegotiation\Factory\RequestFactory',
             'ZF\ContentNegotiation\AcceptListener'            => 'ZF\ContentNegotiation\Factory\AcceptListenerFactory',


### PR DESCRIPTION
I would like to propose this changed registering of `ZF\ContentNegotiation\ContentTypeListener`. Instead of instantiating the class in Module.php I registered it as a `ServiceManager` variable to allow overwrite/customization. The class is now registered under service manager `invokables` in `module.config.php`.