### PR TITLE
Stack trace with 200 OK for empty body

### DIFF
--- a/src/ContentTypeListener.php
+++ b/src/ContentTypeListener.php
@@ -108,6 +108,7 @@ class ContentTypeListener
             return $bodyParams;
         }
 
+        $bodyParams = $bodyParams ?: array();
         $parameterData->setBodyParams($bodyParams);
         $e->setParam('ZFContentNegotiationParameterData', $parameterData);
     }

--- a/test/ContentTypeListenerTest.php
+++ b/test/ContentTypeListenerTest.php
@@ -257,4 +257,27 @@ class ContentTypeListenerTest extends TestCase
         unlink($tmpFile);
         rmdir($tmpDir);
     }
+
+    /**
+     * @group 35
+     * @dataProvider methodsWithBodies
+     */
+    public function testWillNotAttemptToInjectNullValueForBodyParams($method)
+    {
+        $listener = $this->listener;
+
+        $request = new Request();
+        $request->setMethod($method);
+        $request->getHeaders()->addHeaderLine('Content-Type', 'application/json');
+        $request->setContent('');
+
+        $event = new MvcEvent();
+        $event->setRequest($request);
+        $event->setRouteMatch(new RouteMatch(array()));
+
+        $result = $listener($event);
+        $this->assertNull($result);
+        $params = $event->getParam('ZFContentNegotiationParameterData');
+        $this->assertEquals(array(), $params->getBodyParams());
+    }
 }


### PR DESCRIPTION
If I POST, PUT or PATCH to an API with an empty body, I get a stack trace but the response is a "200 OK".

Stack trace is:

Catchable fatal error: Argument 1 passed to ZF\ContentNegotiation\ParameterDataContainer::setBodyParams() must be of the type array, null given, called in /vagrant_web/vendor/zfcampus/zf-content-negotiation/src/ContentTypeListener.php on line 111 and defined in /vagrant_web/vendor/zfcampus/zf-content-negotiation/src/ParameterDataContainer.php on line 132
Call Stack
#	Time	Memory	Function	Location
1	0.0007	241648	{main}( )	../index.php:0
2	0.3045	16616584	Zend\Mvc\Application->run( )	../index.php:30
3	0.3045	16617640	Zend\EventManager\EventManager->trigger( string(5), object(Zend\Mvc\MvcEvent)[325], object(Closure)[418], ??? )	../Application.php:296
4	0.3045	16617640	Zend\EventManager\EventManager->triggerListeners( string(5), object(Zend\Mvc\MvcEvent)[325], object(Closure)[418] )	../EventManager.php:207
5	0.3123	16949456	call_user_func ( object(ZF\ContentNegotiation\ContentTypeListener)[598], object(Zend\Mvc\MvcEvent)[325] )	../EventManager.php:468
6	0.3123	16950024	ZF\ContentNegotiation\ContentTypeListener->__invoke( object(Zend\Mvc\MvcEvent)[325] )	../EventManager.php:468
7	0.3128	16972448	ZF\ContentNegotiation\ParameterDataContainer->setBodyParams( null )	../ContentTypeListener.php:111

