### PR TITLE
Fix for all whitespace within json being trimmed

### DIFF
--- a/src/ContentTypeListener.php
+++ b/src/ContentTypeListener.php
@@ -153,8 +153,7 @@ class ContentTypeListener
     public function decodeJson($json)
     {
         // Trim whitespace from front and end of string to avoid parse errors
-        $json = preg_replace('/^\s*/m', '', $json);
-        $json = preg_replace('/\s*/m', '', $json);
+        $json = trim($json);
 
         $data = json_decode($json, true);
         if (null !== $data) {


### PR DESCRIPTION
@weierophinney V1.0.6 trims all whitespace in the json body including in strings that contain internal spaces. I don't see why trim wouldn't work in this case, but if not, the suggestion @steverhoades mentioned on the commit with adding the $ anchor on the 2nd regex works too.

As a side note, the testOnFinishWillRemoveAnyUploadFilesUploadedByTheListener test fails on mac. This is because in the listener that should remove the uploaded files, the $fileinfo['tmp_name'] starts with /private/var whereas the uploadTmpDir in the listener starts with /var. I think this mapping is just a mac thing but it makes the listener skip the removal of the file.