### PR TITLE
Throw 400 Bad Request when multipart can't be parsed

### DIFF
--- a/src/ContentTypeListener.php
+++ b/src/ContentTypeListener.php
@@ -80,7 +80,16 @@ class ContentTypeListener
 
                 if ($contentType && $contentType->match('multipart/form-data')) {
                     $parser = new MultipartContentParser($contentType, $request);
-                    $bodyParams = $parser->parse();
+                    try {
+                        $bodyParams = $parser->parse();
+                    } catch (Exception\ExceptionInterface $e) {
+                        $bodyParams = new ApiProblemResponse(new ApiProblem(
+                            400,
+                            $e
+                        ));
+                        break;
+                    }
+
                     if ($request->getFiles()->count()) {
                         $this->attachFileCleanupListener($e, $parser->getUploadTempDir());
                     }

--- a/test/TestAsset/multipart-form-data-missing-name.txt
+++ b/test/TestAsset/multipart-form-data-missing-name.txt
@@ -1,0 +1,15 @@
+--6603ddd555b044dc9a022f3ad9281c20
+Content-Disposition: form-data; name="mime_type"
+Content-Type: text/plain
+
+md
+--6603ddd555b044dc9a022f3ad9281c20
+Content-Disposition: form-data; filename="README.md"
+Content-Type: application/octet-stream
+
+ZF Content Negotiation
+======================
+
+[![Build Status](https://travis-ci.org/zfcampus/zf-api-problem.png)](https://travis-ci.org/zfcampus/zf-api-problem)
+
+--6603ddd555b044dc9a022f3ad9281c20--


### PR DESCRIPTION
When parsing Multipart contenet, if for some strange reason the name of the field is empty It should throw a 400 status.

See the [line](https://github.com/zfcampus/zf-content-negotiation/blob/master/src/MultipartContentParser.php#L181)

:)