### PR TITLE
Allow dash-separated keys

### DIFF
--- a/src/ContentNegotiationOptions.php
+++ b/src/ContentNegotiationOptions.php
@@ -31,6 +31,41 @@ class ContentNegotiationOptions extends AbstractOptions
     protected $contentTypeWhitelist = [];
 
     /**
+     * {@inheritDoc}
+     *
+     * Normalizes dash-separated keys to underscore-separated to ensure
+     * backwards compatibility with old options (even though dash-separated
+     * were previously ignored!).
+     *
+     * @see \Zend\Stdlib\ParameterObject::__set()
+     * @param string $key
+     * @param mixed $value
+     * @throws \Zend\Stdlib\Exception\BadMethodCallException
+     * @return void
+     */
+    public function __set($key, $value)
+    {
+        parent::__set(str_replace('-', '_', $key), $value);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Normalizes dash-separated keys to underscore-separated to ensure
+     * backwards compatibility with old options (even though dash-separated
+     * were previously ignored!).
+     *
+     * @see \Zend\Stdlib\ParameterObject::__get()
+     * @param string $key
+     * @throws \Zend\Stdlib\Exception\BadMethodCallException
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return parent::__get(str_replace('-', '_', $key));
+    }
+
+    /**
      * @param array $controllers
      */
     public function setControllers(array $controllers)

--- a/test/ContentNegotiationOptionsTest.php
+++ b/test/ContentNegotiationOptionsTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\ContentNegotiation;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ZF\ContentNegotiation\ContentNegotiationOptions;
+
+class ContentNegotiationOptionsTest extends TestCase
+{
+    public function dashSeparatedOptions()
+    {
+        return [
+            'accept-whitelist' => ['accept-whitelist', 'accept_whitelist'],
+            'content-type-whitelist' => ['content-type-whitelist', 'content_type_whitelist'],
+        ];
+    }
+
+    /**
+     * @dataProvider dashSeparatedOptions
+     */
+    public function testSetNormalizesDashSeparatedKeysToUnderscoreSeparated($key, $normalized)
+    {
+        $options = new ContentNegotiationOptions();
+        $options->{$key} = ['value'];
+        $this->assertEquals(['value'], $options->{$key});
+        $this->assertEquals(['value'], $options->{$normalized});
+    }
+
+    /**
+     * @dataProvider dashSeparatedOptions
+     */
+    public function testConstructorAllowsDashSeparatedKeys($key, $normalized)
+    {
+        $options = new ContentNegotiationOptions([$key => ['value']]);
+        $this->assertEquals(['value'], $options->{$key});
+        $this->assertEquals(['value'], $options->{$normalized});
+    }
+}


### PR DESCRIPTION
Per a number of reports, some modules were using dash-separated keys instead of
underscore_separated keys for content-negotiation options.
zf-content-negotiation was ignoring these previously, but starting with 1.2.0
and the introduction of the ContentNegotiationOptions class, these are now
invalid and raise an exception, breaking applications.

The specific module in question is likely zf-apigility-doctrine, and there's a
PR against that repo to fix it: zfcampus/zf-apigility-doctrine#212.

This patch modifies the options class to munge dash-separated values to ensure
they work.