### PR TITLE
Error if content is not a json

### DIFF
--- a/src/ContentTypeListener.php
+++ b/src/ContentTypeListener.php
@@ -170,12 +170,13 @@ class ContentTypeListener
         }
 
         $data = json_decode($json, true);
-        if (null !== $data) {
+        $isArray = is_array($data);
+        if ($isArray) {
             return $data;
         }
 
         $error = json_last_error();
-        if ($error === JSON_ERROR_NONE) {
+        if ($error === JSON_ERROR_NONE && $isArray) {
             return $data;
         }
 

--- a/test/ContentTypeListenerTest.php
+++ b/test/ContentTypeListenerTest.php
@@ -57,6 +57,30 @@ class ContentTypeListenerTest extends TestCase
         $this->assertContains('JSON decoding', $problem->detail);
     }
 
+    /**
+     * @group 3
+     * @dataProvider methodsWithBodies
+     */
+    public function testJsonDecodeStringErrorsReturnsProblemResponse($method)
+    {
+        $listener = $this->listener;
+
+        $request = new Request();
+        $request->setMethod($method);
+        $request->getHeaders()->addHeaderLine('Content-Type', 'application/json');
+        $request->setContent('"1"');
+
+        $event = new MvcEvent();
+        $event->setRequest($request);
+        $event->setRouteMatch(new RouteMatch([]));
+
+        $result = $listener($event);
+        $this->assertInstanceOf('ZF\ApiProblem\ApiProblemResponse', $result);
+        $problem = $result->getApiProblem();
+        $this->assertEquals(400, $problem->status);
+        $this->assertContains('JSON decoding', $problem->detail);
+    }
+
     public function multipartFormDataMethods()
     {
         return [


### PR DESCRIPTION
When I post
```
"1"
```
as body I get error
```
Argument 1 passed to ZF\ContentNegotiation\ParameterDataContainer::setBodyParams() must be of the type array, string given
```