### PR TITLE
Update ContentTypeListener.php

### DIFF
--- a/src/ContentTypeListener.php
+++ b/src/ContentTypeListener.php
@@ -117,7 +117,7 @@ class ContentTypeListener
             return $bodyParams;
         }
 
-        $bodyParams = $bodyParams ?: [];
+        $bodyParams = is_array($bodyParams) ? $bodyParams : [];
         $parameterData->setBodyParams($bodyParams);
         $e->setParam('ZFContentNegotiationParameterData', $parameterData);
     }


### PR DESCRIPTION
setBodyPararams accepts array only but 

$bodyParams = $content;

sets a string