### PR TITLE
Fix windows path by using DIRECTORY_REPARATOR constant

### DIFF
--- a/test/Filter/RenameUploadTest.php
+++ b/test/Filter/RenameUploadTest.php
@@ -87,7 +87,7 @@ class RenameUploadTest extends TestCase
      */
     public function testMoveUploadedFileSucceedsOnPutAndPatchHttpRequests($method)
     {
-        $target  = $this->targetDir . '/uploaded.txt';
+        $target  = $this->targetDir . DIRECTORY_SEPARATOR . 'uploaded.txt';
         $file    = $this->createUploadFile();
         $request = new HttpRequest();
         $request->setMethod($method);


### PR DESCRIPTION
Test fails on the /
```
1) ZF\ContentNegotiation\Filter\RenameUploadTest::testMoveUploadedFileSucceedsOnPutAndPatchHttpRequests with data set "put" ('PUT')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'C:\Users\MSKRZY~1\AppData\Local\Temp/zf-content-negotiation-filter/target/uploaded.txt'
+'C:\Users\MSKRZY~1\AppData\Local\Temp/zf-content-negotiation-filter/target\uploaded.txt'
```