### PR TITLE
Hotfix inject array data from multipart

### DIFF
--- a/src/MultipartContentParser.php
+++ b/src/MultipartContentParser.php
@@ -289,7 +289,7 @@ class MultipartContentParser
             }
 
             $parameters->set($name, $data);
-        } elseif ($isArray)  {
+        } elseif ($isArray) {
             $parameters->set($name, (array) $content);
         } else {
             $parameters->set($name, $content);

--- a/src/MultipartContentParser.php
+++ b/src/MultipartContentParser.php
@@ -111,7 +111,7 @@ class MultipartContentParser
                     // Time to handle the data we've already parsed!
                     // Data
                     if (! $filename) {
-                        $data->set($name, rtrim($content, "\r\n"));
+                        $this->processContent($data, $name, $content);
                     }
 
                     // File (successful upload so far)
@@ -264,6 +264,36 @@ class MultipartContentParser
         }
 
         return $data->toArray();
+    }
+
+    /**
+     * Process the non-file data.
+     *
+     * @param Parameters $parameters
+     * @param $name
+     * @param $content
+     */
+    protected function processContent(Parameters $parameters, $name, $content)
+    {
+        $isArray    = substr($name, -1, 2) === '[]';
+        $name       = rtrim($name, '[]');
+        $content    = rtrim($content, "\r\n");
+
+        if ($parameters->offsetExists($name)) {
+            $data = $parameters->get($name);
+
+            if (is_array($data)) {
+                $data[] = $content;
+            } else {
+                $data = [$data, $content];
+            }
+
+            $parameters->set($name, $data);
+        } elseif ($isArray)  {
+            $parameters->set($name, (array) $content);
+        } else {
+            $parameters->set($name, $content);
+        }
     }
 
     /**

--- a/test/ContentTypeListenerTest.php
+++ b/test/ContentTypeListenerTest.php
@@ -502,4 +502,31 @@ class ContentTypeListenerTest extends TestCase
         $details = $result->getApiProblem()->toArray();
         $this->assertContains('does not contain a "name" field', $details['detail']);
     }
+
+    public function testReturnsArrayWhenFieldNamesSimilairToPost()
+    {
+        $request = new Request();
+        $request->setMethod('PUT');
+        $request->getHeaders()->addHeaderLine(
+            'Content-Type',
+            'multipart/form-data; boundary=6603ddd555b044dc9a022f3ad9281c20'
+        );
+        $request->setContent(file_get_contents(__DIR__ . '/TestAsset/multipart-form-data-array.txt'));
+
+        $event = new MvcEvent();
+        $event->setRequest($request);
+        $event->setRouteMatch(new RouteMatch([]));
+
+        $listener = $this->listener;
+        $result = $listener($event);
+
+        $parameterData = $event->getParam('ZFContentNegotiationParameterData');
+        $params = $parameterData->getBodyParams();
+        $this->assertEquals([
+            'array_name' => [
+                'array_value_a',
+                'array_value_b'
+            ],
+        ], $params);
+    }
 }

--- a/test/TestAsset/multipart-form-data-array.txt
+++ b/test/TestAsset/multipart-form-data-array.txt
@@ -1,15 +1,12 @@
 --6603ddd555b044dc9a022f3ad9281c20
-Content-Disposition: form-data; name="mime_type"
+Content-Disposition: form-data; name="array_name[]"
 Content-Type: text/plain
 
-md
+array_value_a
 --6603ddd555b044dc9a022f3ad9281c20
-Content-Disposition: form-data; name="text"; filename="README.md"
-Content-Type: application/octet-stream
+Content-Disposition: form-data; name="array_name[]"
+Content-Type: text/plain
 
-ZF Content Negotiation
-======================
-
-[![Build Status](https://travis-ci.org/zfcampus/zf-api-problem.png)](https://travis-ci.org/zfcampus/zf-api-problem)
+array_value_b
 
 --6603ddd555b044dc9a022f3ad9281c20--


### PR DESCRIPTION
for now only supports simple arrays ```name[]```, no named keys support.