### PR TITLE
Allow PHP 7.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ matrix:
     - php: 7
     - php: hhvm 
   allow_failures:
-    - php: 7
     - php: hhvm
   
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ matrix:
       env:
         - EXECUTE_COVERAGE=true
     - php: 7
-    - php: hhvm 
+    - php: hhvm
   allow_failures:
     - php: hhvm
-  
+
 notifications:
   irc: "irc.freenode.org#apigility-dev"
   email: false

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     },
     "require": {
-        "php": "^5.5",
+        "php": "^5.5 || ^7.0",
         "zendframework/zend-eventmanager": "^2.3",
         "zendframework/zend-filter": "^2.3",
         "zendframework/zend-http": "^2.3",


### PR DESCRIPTION
Fixes #69.

Also removes PHP 7 from the Travis `allow_failures` config.