### PR TITLE
Allow using property access on `ZF\Hal\Entity` instances

### DIFF
--- a/src/JsonModel.php
+++ b/src/JsonModel.php
@@ -79,7 +79,9 @@ class JsonModel extends BaseJsonModel
 
         // Use ZF\Hal\Entity's composed entity
         if ($variables instanceof HalEntity) {
-            $variables = $variables->getEntity();
+            $variables = method_exists($variables, 'getEntity')
+                ? $variables->getEntity() // v1.2+
+                : $variables->entity;     // v1.0-1.1.*
         }
 
         // Use ZF\Hal\Collection's composed collection


### PR DESCRIPTION
Fixes #74.

In cases where a zf-hal version prior to 1.4 is installed, we need to use property access (via property overloading) instead of the `getEntity()` method.