### PR TITLE
Hotfix #76 - Parsing string data

### DIFF
--- a/src/ContentTypeListener.php
+++ b/src/ContentTypeListener.php
@@ -101,13 +101,7 @@ class ContentTypeListener
                     break;
                 }
 
-                // Stolen from AbstractRestfulController
                 parse_str($content, $bodyParams);
-                if (!is_array($bodyParams)
-                    || (1 == count($bodyParams) && isset($bodyParams[0]))
-                ) {
-                    $bodyParams = $content;
-                }
                 break;
             default:
                 break;

--- a/src/ContentTypeListener.php
+++ b/src/ContentTypeListener.php
@@ -111,7 +111,6 @@ class ContentTypeListener
             return $bodyParams;
         }
 
-        $bodyParams = $bodyParams ?: [];
         $parameterData->setBodyParams($bodyParams);
         $e->setParam('ZFContentNegotiationParameterData', $parameterData);
     }

--- a/test/ContentTypeListenerTest.php
+++ b/test/ContentTypeListenerTest.php
@@ -598,4 +598,49 @@ class ContentTypeListenerTest extends TestCase
 
         $this->assertEquals($expected, $params->getBodyParams());
     }
+
+    public function methodsWithStringContent()
+    {
+        return [
+            'delete-string'      => ['DELETE', 'String Content', 'String_Content'],
+            'delete-zero-key'    => ['DELETE', '0=', 0],
+            'delete-empty-value' => ['DELETE', 'ids=', 'ids'],
+            'patch-string'       => ['PATCH', '@String-Content', '@String-Content'],
+            'patch-zero-key'     => ['PATCH', '0=', 0],
+            'patch-empty-value'  => ['PATCH', 'name=', 'name'],
+            'put-string'         => ['PUT', 'string.content', 'string_content'],
+            'put-zero-key'       => ['PUT', '0=', 0],
+            'put-empty-value'    => ['PUT', 'key=', 'key'],
+        ];
+    }
+
+    /**
+     * @dataProvider methodsWithStringContent
+     *
+     * @param string $method
+     * @param string $data
+     * @param string $key
+     */
+    public function testStringContentIsParsedCorrectlyToAnArray($method, $data, $key)
+    {
+        $listener = $this->listener;
+
+        $request = new Request();
+        $request->setMethod($method);
+        $request->setContent($data);
+
+        $event = new MvcEvent();
+        $event->setRequest($request);
+        $event->setRouteMatch($this->createRouteMatch([]));
+
+        $result = $listener($event);
+        $this->assertNull($result);
+
+        /** @var \ZF\ContentNegotiation\ParameterDataContainer $params */
+        $params = $event->getParam('ZFContentNegotiationParameterData');
+        $array = $params->getBodyParams();
+
+        $this->assertArrayHasKey($key, $array);
+        $this->assertSame('', $array[$key]);
+    }
 }


### PR DESCRIPTION
Fix for #76.

I couldn't find any example of `$content` when `parse_str($content, $bodyParams);` will store in `$bodyParams` non-array value.

The removed condition, stolen from `AbstractRestfulController`, in `ContentTypeListener` was stolen incorrectly.
The original condition in `AbstractRestfulController` is (with comment, and renamed variables to fit our code):

```php
// If parse_str fails to decode, or we have a single element with empty value
if (!is_array($bodyParams) || empty($bodyParams)
    || (1 == count($bodyParams) && '' === reset($bodyParams))
) {
```

so in case when `$content` has value`name=` (or just `some string value`) the above condition is satisfied.

In apigility, for both these cases, removed condition was not satisfied (because `$bodyParams[0]` was not set). Only one issue was there when content was `0=`, `0=something` (or just `0`). In all of these cases it was *correctly* parsed to an array (with key `0`), but because of the (removed) condition, `$bodyParams` has then string raw content (`0=`, `0=something`, `0` respectively). In this case fatal error occurs due to type mismatch (`setBodyParams()` requires an array). Apigility is built to have always body parameters as an array and it's not allowing to have string value (unlike the `AbstractRestfulController`).

**To emphasize again:** I can't find any example when `!is_array($bodyParams)` condition will be satisfied.

In this situation, I've decided to remove the condition at all, because as long as `$bodyParams` is always an array, there is no any issue. I think, this is better approach, because probably we don't want to return any `ApiProblemResponse` in case when content is `name=` (please notice, in this situation original condition in `AbstractRestfulController` will be satisfied!).

In conclusion, as we know that `$bodyParams` is always array, line 120 was also redundant, so it's removed.