### PR TITLE
Missing AbstractPluginManager requirement

### DIFF
--- a/src/Factory/RenameUploadFilterFactory.php
+++ b/src/Factory/RenameUploadFilterFactory.php
@@ -7,6 +7,7 @@
 namespace ZF\ContentNegotiation\Factory;
 
 use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use ZF\ContentNegotiation\Filter\RenameUpload;


### PR DESCRIPTION
Doesn't set `Request` without it, so whole overriden `RenameUploadFilter` doesn't work.