### PR TITLE
Assume content-type of application/json if not provided

### DIFF
--- a/src/ContentTypeListener.php
+++ b/src/ContentTypeListener.php
@@ -101,7 +101,14 @@ class ContentTypeListener
                     break;
                 }
 
-                parse_str($content, $bodyParams);
+                // Try to assume JSON if content starts like JSON and no explicit Content-Type was provided
+                if (! $bodyParams && in_array($content[0], ['{', '['], true)) {
+                    $bodyParams = $this->decodeJson($content);
+                }
+
+                if (! $bodyParams || $bodyParams instanceof ApiProblemResponse) {
+                    parse_str($content, $bodyParams);
+                }
                 break;
             default:
                 break;

--- a/test/ContentTypeListenerTest.php
+++ b/test/ContentTypeListenerTest.php
@@ -227,8 +227,12 @@ class ContentTypeListenerTest extends TestCase
         $p->setAccessible(true);
         $p->setValue($this->listener, $tmpDir);
 
+        if (strpos(PHP_OS, 'Darwin') !== false) {
+            $tmpFile = '/private/var/' . $tmpFile;
+        }
+
         $this->listener->onFinish($event);
-        $this->assertFalse(file_exists($tmpFile));
+        $this->assertFileNotExists($tmpFile);
     }
 
     public function testOnFinishDoesNotRemoveUploadFilesTheListenerDidNotCreate()


### PR DESCRIPTION
If a request comes in with no set Content-Type header, we're assuming it's standard form data as the default results in a call to parse_str. However, if the content is JSON, the result from parse_str is an array where the key is the entire JSON body as text and the value is an empty string. Later this value is used with array_keys to set the validation group for validating a PATCH request which causes this error:

https://github.com/zfcampus/zf-content-validation/issues/58

This PR updates the code so that if the incoming request has no explicit content type and the first character of the request is `{` or `[` then we try it as JSON. If the JSON doesn't parse right then we fall back to default behavior of using parse_str.