### PR TITLE
Fixes uninitialized string offset error

### DIFF
--- a/src/ContentTypeListener.php
+++ b/src/ContentTypeListener.php
@@ -102,7 +102,7 @@ class ContentTypeListener
                 }
 
                 // Try to assume JSON if content starts like JSON and no explicit Content-Type was provided
-                if (! $bodyParams && in_array($content[0], ['{', '['], true)) {
+                if (! $bodyParams && strlen($content) > 0 && in_array($content[0], ['{', '['], true)) {
                     $bodyParams = $this->decodeJson($content);
                 }
 


### PR DESCRIPTION
As reported in #96, since #94 and the 1.3.1 release, if the body content for a PUT, PATCH, or DELETE call is empty, an "Uninitialized string offset: 0" notice is raised.

This patch does the following:

- Adds tests missing from the original patch created for #94, verifying that JSON deserialization occurs for those HTTP methods if the content looks like JSON but no Content-Type header was present.
- Adds tests demonstrating that _empty_ content in those same situations will not result in an error, and a fix to the code to make that test pass.