### PR TITLE
Allow using zend-console to determine if a CLI env is in play

### DIFF
--- a/src/Factory/RequestFactory.php
+++ b/src/Factory/RequestFactory.php
@@ -7,6 +7,7 @@
 namespace ZF\ContentNegotiation\Factory;
 
 use Interop\Container\ContainerInterface;
+use Zend\Console\Console;
 use Zend\Console\Request as ConsoleRequest;
 use ZF\ContentNegotiation\Request as HttpRequest;
 
@@ -18,10 +19,14 @@ class RequestFactory
      */
     public function __invoke(ContainerInterface $container)
     {
-        if (PHP_SAPI === 'cli') {
-            return new ConsoleRequest();
+        // If console tooling is present, use that to determine whether or not
+        // we are in a console environment. This approach allows overriding the
+        // environment for purposes of testing HTTP requests from the CLI.
+        if (class_exists(Console::class)) {
+            return Console::isConsole() ? new ConsoleRequest() : new HttpRequest();
         }
 
-        return new HttpRequest();
+        // If console tooling is not present, we use the PHP_SAPI value to decide.
+        return PHP_SAPI === 'cli' ? new ConsoleRequest() : new HttpRequest();
     }
 }


### PR DESCRIPTION
This patch updates #86 to fix #98 by testing if the `Zend\Console\Console` class is present and, if so, using the return value of its `isConsole()` method to determine the current SAPI environment. This approach allows overriding the environment for purposes of unit testing incoming HTTP requests.

If the class is not available, we fallback to the `PHP_SAPI` value.

Fixes #98