### PR TITLE
Merge configuration keys

### DIFF
--- a/src/ContentNegotiationOptions.php
+++ b/src/ContentNegotiationOptions.php
@@ -86,11 +86,11 @@ class ContentNegotiationOptions extends AbstractOptions
                     $config[$normalizedKey]
                 );
 
-                unset($config[$key]);
+                unset($mergedConfig[$key]);
             } elseif (isset($config[$key])) {
                 $mergedConfig[$normalizedKey] = $config[$key];
 
-                unset($config[$key]);
+                unset($mergedConfig[$key]);
             } elseif (isset($config[$normalizedKey])) {
                 $mergedConfig[$normalizedKey] = $config[$normalizedKey];
             }
@@ -103,6 +103,8 @@ class ContentNegotiationOptions extends AbstractOptions
      * @param string $key
      *
      * @return string
+     * @deprecated Should be removed in next major version and only one
+     *             configuration key should be supported.
      */
     private function normalizeKey($key)
     {

--- a/test/ContentNegotiationOptionsTest.php
+++ b/test/ContentNegotiationOptionsTest.php
@@ -56,7 +56,8 @@ class ContentNegotiationOptionsTest extends TestCase
             $normalizedValue,
         ];
 
-        $options = new ContentNegotiationOptions(
+        $options = new ContentNegotiationOptions();
+        $options->setFromArray(
             [
                 $key => [
                     $keyValue,

--- a/test/ContentNegotiationOptionsTest.php
+++ b/test/ContentNegotiationOptionsTest.php
@@ -41,4 +41,41 @@ class ContentNegotiationOptionsTest extends TestCase
         $this->assertEquals(['value'], $options->{$key});
         $this->assertEquals(['value'], $options->{$normalized});
     }
+
+    /**
+     * @dataProvider dashSeparatedOptions
+     */
+    public function testDashAndUnderscoreSeparatedValuesGetMerged(
+        $key,
+        $normalized
+    ) {
+        $keyValue = 'valueKey';
+        $normalizedValue = 'valueNormalized';
+        $expectedResult = [
+            $keyValue,
+            $normalizedValue,
+        ];
+
+        $options = new ContentNegotiationOptions(
+            [
+                $key => [
+                    $keyValue,
+                ],
+                $normalized => [
+                    $normalizedValue,
+                ],
+            ]
+        );
+
+        $this->assertEquals(
+            $expectedResult,
+            $options->{$key},
+            'The value for the hyphen separated key was not as expected.'
+        );
+        $this->assertEquals(
+            $expectedResult,
+            $options->{$normalized},
+            'The value for the normalized key was not as expected.'
+        );
+    }
 }

--- a/test/Factory/ContentNegotiationOptionsFactoryTest.php
+++ b/test/Factory/ContentNegotiationOptionsFactoryTest.php
@@ -21,7 +21,7 @@ class ContentNegotiationOptionsFactoryTest extends TestCase
         ];
 
         $serviceManager = new ServiceManager();
-        $serviceManager->setService('Config', $config);
+        $serviceManager->setService('config', $config);
 
         $factory = new ContentNegotiationOptionsFactory();
 

--- a/test/Factory/ContentNegotiationOptionsFactoryTest.php
+++ b/test/Factory/ContentNegotiationOptionsFactoryTest.php
@@ -29,4 +29,22 @@ class ContentNegotiationOptionsFactoryTest extends TestCase
 
         $this->assertInstanceOf('ZF\ContentNegotiation\ContentNegotiationOptions', $service);
     }
+
+    public function testCreateServiceShouldReturnContentNegotiationOptionsInstanceWithOptions()
+    {
+        $config = [
+            'zf-content-negotiation' => [
+                'accept_whitelist' => [],
+            ],
+        ];
+
+        $serviceManager = new ServiceManager();
+        $serviceManager->setService('config', $config);
+
+        $factory = new ContentNegotiationOptionsFactory();
+
+        $service = $factory($serviceManager, 'ContentNegotiationOptions');
+
+        $this->assertNotEmpty($service->toArray());
+    }
 }

--- a/test/Factory/ContentNegotiationOptionsFactoryTest.php
+++ b/test/Factory/ContentNegotiationOptionsFactoryTest.php
@@ -47,4 +47,15 @@ class ContentNegotiationOptionsFactoryTest extends TestCase
 
         $this->assertNotEmpty($service->toArray());
     }
+
+    public function testCreateServiceWithoutConfigShouldReturnContentNegotiationOptionsInstance()
+    {
+        $serviceManager = new ServiceManager();
+
+        $factory = new ContentNegotiationOptionsFactory();
+
+        $service = $factory($serviceManager, 'ContentNegotiationOptions');
+
+        $this->assertNotEmpty($service->toArray());
+    }
 }


### PR DESCRIPTION
Fix for #99 

I can create a single commit, if that is preferred, but I thought for reviewing this is easier.

I added functionality to ContentNegotiationOptions that merges the - i call them legacy - config keys into one big one, so that different modules do not overwrite each other anymore.

Also I found a bug in the ContentNegotiationOptionsFactoryTest. The service key `config` has to be written in lower case, at least for your factory setup. I corrected that and recognized, that the test was not covering the whole factory. So I added two more test cases that should cover the whole factory class and its paths.

